### PR TITLE
Feature/Move get_or_create logic into the QuerySet

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,5 @@
 import django
 import os
-import shutil
 
 
 def pytest_report_header(config):
@@ -11,9 +10,3 @@ def pytest_configure(config):
     # using test version of settings.py
     os.environ['DJANGO_SETTINGS_MODULE'] = "estimators.tests.settings"
     django.setup()
-
-
-def pytest_unconfigure(config):
-    """Remove tmp directory for testings"""
-    from estimators.tests import settings
-    shutil.rmtree(settings.MEDIA_ROOT)

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 import django
 import os
+import shutil
 
 
 def pytest_report_header(config):
@@ -10,3 +11,9 @@ def pytest_configure(config):
     # using test version of settings.py
     os.environ['DJANGO_SETTINGS_MODULE'] = "estimators.tests.settings"
     django.setup()
+
+
+def pytest_unconfigure(config):
+    """Remove tmp directory for testings"""
+    from estimators.tests import settings
+    shutil.rmtree(settings.MEDIA_ROOT)

--- a/data-requirements.txt
+++ b/data-requirements.txt
@@ -1,3 +1,0 @@
-numpy==1.11.1
-scipy==0.18.1
-scikit-learn==0.17.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,12 @@
 coverage==4.2
-isort==4.2.5
-tox==2.3.1
-pytest-django==3.0.0
+coveralls==1.1
 factory-boy==2.7.0
+# isort==4.2.5
+numpy==1.11.1
+pytest==3.0.3
+pytest-cov==2.4.0
+pytest-django==3.0.0
+pytest-xdist==1.15.0
+scikit-learn==0.17.1
+scipy==0.18.1
+tox==2.3.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ coverage==4.2
 isort==4.2.5
 tox==2.3.1
 pytest-django==3.0.0
+factory-boy==2.7.0

--- a/estimators/models/base.py
+++ b/estimators/models/base.py
@@ -18,6 +18,12 @@ class HashableFileQuerySet(models.QuerySet):
 
     object_property_name = NotImplementedError()
 
+    def filter(self, *args, **kwargs):
+        obj = kwargs.pop(self.object_property_name, None)
+        if obj is not None:
+            kwargs['object_hash'] = self.model._compute_hash(obj)
+        return super().filter(*args, **kwargs)
+
     def _extract_model_params(self, defaults, **kwargs):
         obj = kwargs.pop(self.object_property_name, None)
         if obj is not None:

--- a/estimators/models/base.py
+++ b/estimators/models/base.py
@@ -19,12 +19,16 @@ class HashableFileQuerySet(models.QuerySet):
     object_property_name = NotImplementedError()
 
     def filter(self, *args, **kwargs):
+        """filter lets django managers use `objects.filter` on a hashable object."""
         obj = kwargs.pop(self.object_property_name, None)
         if obj is not None:
             kwargs['object_hash'] = self.model._compute_hash(obj)
         return super().filter(*args, **kwargs)
 
     def _extract_model_params(self, defaults, **kwargs):
+        """this method allows django managers use `objects.get_or_create` and
+        `objects.update_or_create` on a hashable object.
+        """
         obj = kwargs.pop(self.object_property_name, None)
         if obj is not None:
             kwargs['object_hash'] = self.model._compute_hash(obj)
@@ -104,6 +108,7 @@ class HashableFileMixin(models.Model):
 
     @classmethod
     def get_or_create(cls, obj):
+        """Deprecated in favor for the canonical `objects.get_or_create` method"""
         raise DeprecationWarning('Please use `%s.objects.get_or_create()` instead' % cls)
 
     @classmethod

--- a/estimators/models/base.py
+++ b/estimators/models/base.py
@@ -67,7 +67,7 @@ class HashableFileMixin(models.Model):
         if self.object_hash:
             data = dill.dumps(self.object_property)
             f = ContentFile(data)
-            self.object_file.save(self.object_hash, f)
+            self.object_file.save(self.object_hash, f, save=False)
             f.close()
             return True
         return False

--- a/estimators/models/datasets.py
+++ b/estimators/models/datasets.py
@@ -1,6 +1,11 @@
 from django.db import models
 
-from estimators.models.base import HashableFileMixin
+from estimators.models.base import HashableFileMixin, HashableFileQuerySet
+
+
+class DataSetQuerySet(HashableFileQuerySet):
+
+    object_property_name = 'data'
 
 
 class DataSet(HashableFileMixin):
@@ -8,6 +13,8 @@ class DataSet(HashableFileMixin):
     description = models.CharField(max_length=256)
     _data = None
     _object_property_name = '_data'
+
+    objects = DataSetQuerySet.as_manager()
 
     class Meta:
         db_table = 'data_sets'

--- a/estimators/models/estimators.py
+++ b/estimators/models/estimators.py
@@ -28,7 +28,7 @@ class Estimator(HashableFileMixin):
         or
 
             >>> from estimators.models import Estimator
-            >>> est = Estimator.get_or_create(object)
+            >>> est = Estimator.objects.get_or_create(estimator=object)
             >>> est.description = "kNN without parameter tuning"
             >>> est.save()
     """
@@ -46,12 +46,6 @@ class Estimator(HashableFileMixin):
     def __repr__(self):
         return '<Estimator <Id %s> <Hash %s>: %s>' % (
             self.id, self.object_hash, self.estimator)
-
-    @classmethod
-    def get_by_estimator(cls, est):
-        if est is not None:
-            object_hash = cls._compute_hash(est)
-        return cls.get_by_hash(object_hash)
 
     @property
     def estimator(self):
@@ -72,7 +66,7 @@ class Estimator(HashableFileMixin):
                 "object_hash '%s' should be set by the estimator '%s'" %
                 (self.object_hash, self.estimator))
         # if already persisted, do not update estimator
-        obj = self.get_by_hash(self.object_hash)
+        obj = Estimator.objects.filter(object_hash=self.object_hash).first()
         if self.id and self.object_hash != getattr(obj, 'object_hash', None):
             raise ValidationError(
                 "Cannot persist updated estimator '%s'.  Create a new Estimator object." %

--- a/estimators/models/estimators.py
+++ b/estimators/models/estimators.py
@@ -2,7 +2,12 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 
-from estimators.models.base import HashableFileMixin
+from estimators.models.base import HashableFileMixin, HashableFileQuerySet
+
+
+class EstimatorQuerySet(HashableFileQuerySet):
+
+    object_property_name = 'estimator'
 
 
 class Estimator(HashableFileMixin):
@@ -32,6 +37,8 @@ class Estimator(HashableFileMixin):
     _estimator = None
     # required by base class, to refer to the estimator property
     _object_property_name = '_estimator'
+
+    objects = EstimatorQuerySet.as_manager()
 
     class Meta:
         db_table = 'estimators'

--- a/estimators/models/evaluations.py
+++ b/estimators/models/evaluations.py
@@ -87,12 +87,14 @@ class Evaluator(EvaluationMixin):
         return er
 
     def persist_results(self, er):
-        er._estimator_proxy = Estimator.get_or_create(
-            er._estimator_proxy.estimator)
-        er._X_test_proxy = DataSet.get_or_create(er._X_test_proxy.data)
-        er._y_test_proxy = DataSet.get_or_create(er._y_test_proxy.data)
-        er._y_predicted_proxy = DataSet.get_or_create(
-            er._y_predicted_proxy.data)
+        er._estimator_proxy, _ = Estimator.objects.get_or_create(
+            estimator=er._estimator_proxy.estimator)
+        er._X_test_proxy, _ = DataSet.objects.get_or_create(
+            data=er._X_test_proxy.data)
+        er._y_test_proxy, _ = DataSet.objects.get_or_create(
+            data=er._y_test_proxy.data)
+        er._y_predicted_proxy, _ = DataSet.objects.get_or_create(
+            data=er._y_predicted_proxy.data)
         er.save()
 
     def __repr__(self):

--- a/estimators/tests/factories.py
+++ b/estimators/tests/factories.py
@@ -23,10 +23,8 @@ class EstimatorFactory(DjangoModelFactory):
 
     class Meta:
         model = Estimator
-        strategy = 'build'
 
     estimator = factory.Iterator([
-        RandomForestRegressor(),
         RandomForestClassifier(),
     ])
 
@@ -34,12 +32,17 @@ class EstimatorFactory(DjangoModelFactory):
     object_file = DjangoFileField(
         filename=lambda o: 'files/estimators/%s' % o.object_hash)
 
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        obj = model_class(*args, **kwargs)
+        obj.save()
+        return obj
+
 
 class DataSetFactory(DjangoModelFactory):
 
     class Meta:
         model = DataSet
-        strategy = 'build'
 
     class Params:
         min_random_value = 0
@@ -56,12 +59,17 @@ class DataSetFactory(DjangoModelFactory):
     object_hash = factory.LazyAttribute(lambda o: compute_hash(o.data))
     object_file = DjangoFileField(filename='the_file.dat')
 
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        obj = model_class(*args, **kwargs)
+        obj.save()
+        return obj
+
 
 class EvaluationResultFactory(DjangoModelFactory):
 
     class Meta:
         model = EvaluationResult
-        strategy = 'build'
 
     create_date = factory.LazyFunction(datetime.now)
     _estimator_proxy = factory.SubFactory(EstimatorFactory)

--- a/estimators/tests/factories.py
+++ b/estimators/tests/factories.py
@@ -1,15 +1,14 @@
 from datetime import datetime
 
-import numpy as np
-from sklearn.ensemble import RandomForestClassifier
-
 import factory
 import factory.fuzzy
-from estimators import hashing
-from estimators.models import DataSet, Estimator, EvaluationResult
+import numpy as np
 from factory.django import FileField as DjangoFileField
 from factory.django import DjangoModelFactory
+from sklearn.ensemble import RandomForestClassifier
 
+from estimators import hashing
+from estimators.models import DataSet, Estimator, EvaluationResult
 
 __all__ = ['EstimatorFactory', 'DataSetFactory', 'EvaluationResultFactory']
 

--- a/estimators/tests/factories.py
+++ b/estimators/tests/factories.py
@@ -11,6 +11,9 @@ from factory.django import FileField as DjangoFileField
 from factory.django import DjangoModelFactory
 
 
+__all__ = ['EstimatorFactory', 'DataSetFactory', 'EvaluationResultFactory']
+
+
 def compute_hash(obj):
     return hashing.hash(obj)
 
@@ -23,6 +26,7 @@ class EstimatorFactory(DjangoModelFactory):
 
     class Meta:
         model = Estimator
+        django_get_or_create = ('object_hash',)
 
     estimator = factory.Iterator([
         RandomForestClassifier(),
@@ -33,17 +37,12 @@ class EstimatorFactory(DjangoModelFactory):
     object_file = DjangoFileField(
         filename=lambda o: 'files/estimators/%s' % o.object_hash)
 
-    @classmethod
-    def _create(cls, model_class, *args, **kwargs):
-        obj = model_class(*args, **kwargs)
-        obj.save()
-        return obj
-
 
 class DataSetFactory(DjangoModelFactory):
 
     class Meta:
         model = DataSet
+        django_get_or_create = ('object_hash',)
 
     class Params:
         min_random_value = 0
@@ -60,12 +59,6 @@ class DataSetFactory(DjangoModelFactory):
     object_hash = factory.LazyAttribute(lambda o: compute_hash(o.data))
     object_file = DjangoFileField(
         filename=lambda o: 'files/datasets/%s' % o.object_hash)
-
-    @classmethod
-    def _create(cls, model_class, *args, **kwargs):
-        obj = model_class(*args, **kwargs)
-        obj.save()
-        return obj
 
 
 class EvaluationResultFactory(DjangoModelFactory):

--- a/estimators/tests/factories.py
+++ b/estimators/tests/factories.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import numpy as np
-from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.ensemble import RandomForestClassifier
 
 import factory
 import factory.fuzzy
@@ -28,6 +28,7 @@ class EstimatorFactory(DjangoModelFactory):
         RandomForestClassifier(),
     ])
 
+    create_date = factory.LazyFunction(datetime.now)
     object_hash = factory.LazyAttribute(lambda o: compute_hash(o.estimator))
     object_file = DjangoFileField(
         filename=lambda o: 'files/estimators/%s' % o.object_hash)
@@ -57,7 +58,8 @@ class DataSetFactory(DjangoModelFactory):
 
     create_date = factory.LazyFunction(datetime.now)
     object_hash = factory.LazyAttribute(lambda o: compute_hash(o.data))
-    object_file = DjangoFileField(filename='the_file.dat')
+    object_file = DjangoFileField(
+        filename=lambda o: 'files/datasets/%s' % o.object_hash)
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):

--- a/estimators/tests/settings.py
+++ b/estimators/tests/settings.py
@@ -21,4 +21,7 @@ TEST_DATABASE_NAME = ':memory:'
 
 MIDDLEWARE_CLASSES = []
 
-MEDIA_ROOT = 'tmp/'
+import tempfile
+MEDIA_ROOT = tempfile.gettempdir()
+
+DEBUG = True

--- a/estimators/tests/test_estimators.py
+++ b/estimators/tests/test_estimators.py
@@ -33,11 +33,11 @@ class TestEstimator():
         assert m.is_persisted == True
 
     def test_get_or_create(self):
-        m = Estimator.get_or_create('new_original_object')
+        m, created = Estimator.objects.get_or_create(estimator='new_original_object')
         m.save()
         assert m.estimator == 'new_original_object'
 
-        n = Estimator.get_or_create('new_original_object')
+        n, created = Estimator.objects.get_or_create(estimator='new_original_object')
         assert m == n
 
     def test_create_from_file(self):

--- a/estimators/tests/test_estimators.py
+++ b/estimators/tests/test_estimators.py
@@ -1,21 +1,29 @@
-import os
 
 import pytest
 from django.core.exceptions import ValidationError
 
 from estimators.models.estimators import Estimator
+from estimators.tests.factories import EstimatorFactory
 
 
 @pytest.mark.django_db
 class TestEstimator():
 
-    def test_object_hash(self):
-        m = Estimator(estimator=object, description='object test')
+    def test_estimator_persistance_without_factory(self):
+        m = Estimator(estimator='new string', description='another object')
+        assert m.object_file.storage.exists(m.object_file.path) == False
+        assert m.is_persisted == False
+
         m.save()
+        assert m.object_file.storage.exists(m.object_file.path) == True
+        assert m.is_persisted == True
+
+    def test_object_hash_with_factory(self):
+        m = EstimatorFactory(estimator=object)
         assert m.estimator == object
         del m
 
-        n = Estimator.objects.get(description='object test')
+        n = Estimator.objects.filter(estimator=object).first()
         # sklearn hash of a object = 'd9c9f286391652b89978a6961b52b674'
         assert n.object_hash == 'd9c9f286391652b89978a6961b52b674'
         # assert loaded after calling n.estimator
@@ -23,27 +31,30 @@ class TestEstimator():
         assert Estimator._compute_hash(
             object) == 'd9c9f286391652b89978a6961b52b674'
 
-    def test_estimator_persistance(self):
-        m = Estimator(estimator=object, description='another object')
-        assert os.path.exists(m.object_file.path) == False
-        assert m.is_persisted == False
-
-        m.save()
-        assert os.path.exists(m.object_file.path) == True
-        assert m.is_persisted == True
-
     def test_get_or_create(self):
-        m, created = Estimator.objects.get_or_create(estimator='new_original_object')
+        m, created = Estimator.objects.get_or_create(estimator='new_string_as_object')
         m.save()
-        assert m.estimator == 'new_original_object'
+        assert m.estimator == 'new_string_as_object'
+        assert created == True
 
-        n, created = Estimator.objects.get_or_create(estimator='new_original_object')
+        n, created = Estimator.objects.get_or_create(estimator='new_string_as_object')
         assert m == n
+        assert created == False
 
-    def test_create_from_file(self):
-        obj = "{'key': 'value'}"
-        m = Estimator(estimator=obj)
+    def test_update_or_create(self):
+        e = 'estimator_obj'
+        m, created = Estimator.objects.update_or_create(estimator=e)
         m.save()
+        assert m.estimator == e
+        assert created == True
+
+        n, created = Estimator.objects.update_or_create(estimator=e)
+        assert m == n
+        assert created == False
+
+    def test_create_from_file_with_factory(self):
+        obj = "{'key': 'value'}"
+        m = EstimatorFactory(estimator=obj)
         object_hash = m.object_hash
         file_path = m.object_file.name
         del m
@@ -51,6 +62,7 @@ class TestEstimator():
         m = Estimator.create_from_file(file_path)
         assert m.estimator == obj
         assert m.object_hash == object_hash
+        assert m.is_persisted == False
 
     def test_update_estimator_fail(self):
         m = Estimator(estimator='uneditable_object')
@@ -64,12 +76,13 @@ class TestEstimator():
         object_hash = Estimator._compute_hash('abcd')
         assert object_hash == '3062a9e3345c129799bd2c1603c2e966'
 
-    def test_object_hash_diff_fail(self):
+    def test_hash_without_estimator_fail(self):
         m = Estimator()
         m.object_hash = 'randomly set hash'
         with pytest.raises(ValidationError):
             m.save()
 
+    def test_wrong_hash_fail(self):
         m = Estimator(estimator='unique_object')
         m.object_hash = 'randomly set hash'
         with pytest.raises(ValidationError):

--- a/tox.ini
+++ b/tox.ini
@@ -13,14 +13,8 @@ passenv =
 setenv =
     COVERALLS_REPO_TOKEN = LglxW98a02WKFTVKqJeVoEpDKJ31ezQ8I
 deps =
-    six
-    coveralls
-    pytest
-    pytest-django
-    pytest-cov
-    pytest-xdist
     -r{toxinidir}/requirements.txt
-    -r{toxinidir}/data-requirements.txt
+    -r{toxinidir}/dev-requirements.txt
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
@@ -36,9 +30,8 @@ commands =
 [testenv:isort]
 deps =
     isort==4.2.5
-    pytest
     -r{toxinidir}/requirements.txt
-    -r{toxinidir}/data-requirements.txt
+    -r{toxinidir}/dev-requirements.txt
     Django>=1.10,<1.11
 commands = 
     isort --diff -rc -c estimators


### PR DESCRIPTION
This PR deprecates the `get_or_create` classmethod and advocates using the traditional django approach of `objects.get_or_create` instead.

The goal of this is to keep the Estimator, and DataSet logic focuses on the data model, and not the manager or queryset operations.

Additionally,
* Fix a bug with a double save on the `file.save()`
* Add support for `objects.update_or_create(..)`
* Add support for `objects.filter(..)`
* Add support for `Estimator.objects` methods to accept the `estimator` kwarg and compute and use the hash for retrieval
* Add support for `DataSet.objects` methods to accept the `data`  kwarg and compute and use the hash for retrieval