### PR TITLE
Add Instructions for Notebook Use

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,19 +161,30 @@ And you can view all the atributes on the evaluation result
     result.y_predicted
 
 
-Using with Notebook (or without django shell)
+Using with Jupyter Notebook (or without a django app)
 ---------------------------------------------
 
-In order to have access to the django db, you'll need to set up the environment variable to load up your django project.  In ipython, you can set the environment variable ``DJANGO_SETTINGS_MODULE`` to ``your_project_name.settings`` like so::
+Django-Estimators can run as a standalone django app.In order to have access to the django db, you'll need to set up the environment variable to load up your django project.  In ipython, by default you can set the environment variable ``DJANGO_SETTINGS_MODULE`` to ``estimators.template_settings`` like so
+::
 
     import os
     import django
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "your_project_name.settings")
+    os.environ['DJANGO_SETTINGS_MODULE'] = "estimators.template_settings"
     django.setup()
 
-Now you can continue on as usual... ::
+If you're creating a new database (by default it's ``db.sqlite3``), in python, you'll need to run
+::
+
+    from django.core.management import call_command
+    call_command('migrate')
+
+
+Now you can continue you as usual... ::
 
     from estimators.models import Estimator
+
+
+To use your own custom settings, make a copy of the ``estimators.template_settings`` and edit the fields.  Like above, run ``os.environ['DJANGO_SETTINGS_MODULE'] = "custom_settings_file"`` before running ``django.setup()``.
 
 
 Development Installation 

--- a/estimators/models/datasets.py
+++ b/estimators/models/datasets.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from estimators import DATASET_DIR
 from estimators.models.base import HashableFileMixin, HashableFileQuerySet
 
 
@@ -15,6 +16,8 @@ class DataSet(HashableFileMixin):
     _object_property_name = '_data'
 
     objects = DataSetQuerySet.as_manager()
+
+    DIRECTORY = DATASET_DIR
 
     class Meta:
         db_table = 'data_sets'

--- a/estimators/models/estimators.py
+++ b/estimators/models/estimators.py
@@ -2,6 +2,7 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 
+from estimators import ESTIMATOR_DIR
 from estimators.models.base import HashableFileMixin, HashableFileQuerySet
 
 
@@ -39,6 +40,8 @@ class Estimator(HashableFileMixin):
     _object_property_name = '_estimator'
 
     objects = EstimatorQuerySet.as_manager()
+
+    DIRECTORY = ESTIMATOR_DIR
 
     class Meta:
         db_table = 'estimators'

--- a/estimators/template_settings.py
+++ b/estimators/template_settings.py
@@ -1,0 +1,26 @@
+SECRET_KEY = 'template settings file'
+
+INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.admin',
+    'estimators',
+)
+
+DATABASE_ENGINE = 'sqlite3',
+DATABASES = {
+    'default': {
+        'NAME': 'db.sqlite3',
+        'ENGINE': 'django.db.backends.sqlite3',
+    },
+}
+
+MIDDLEWARE_CLASSES = []
+
+MEDIA_ROOT = 'files'
+
+ESTIMATOR_DIR = 'estimators/'
+DATASET_DIR = 'datasets/'
+
+DEBUG = True

--- a/estimators/tests/factories.py
+++ b/estimators/tests/factories.py
@@ -34,7 +34,7 @@ class EstimatorFactory(DjangoModelFactory):
     create_date = factory.LazyFunction(datetime.now)
     object_hash = factory.LazyAttribute(lambda o: compute_hash(o.estimator))
     object_file = DjangoFileField(
-        filename=lambda o: 'files/estimators/%s' % o.object_hash)
+        filename=lambda o: '%s/%s' % (Estimator.DIRECTORY, o.object_hash))
 
 
 class DataSetFactory(DjangoModelFactory):
@@ -57,7 +57,7 @@ class DataSetFactory(DjangoModelFactory):
     create_date = factory.LazyFunction(datetime.now)
     object_hash = factory.LazyAttribute(lambda o: compute_hash(o.data))
     object_file = DjangoFileField(
-        filename=lambda o: 'files/datasets/%s' % o.object_hash)
+        filename=lambda o: '%s/%s' % (DataSet.DIRECTORY, o.object_hash))
 
 
 class EvaluationResultFactory(DjangoModelFactory):

--- a/estimators/tests/settings.py
+++ b/estimators/tests/settings.py
@@ -22,6 +22,7 @@ TEST_DATABASE_NAME = ':memory:'
 MIDDLEWARE_CLASSES = []
 
 import tempfile
+
 MEDIA_ROOT = tempfile.gettempdir()
 
 DEBUG = True


### PR DESCRIPTION
This PR

* add instructions on using django-estimators without a django project.
* removes hardcoded dependancy for factories using the estimator and dataset directory